### PR TITLE
Fix broken links to the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,5 +50,5 @@ The following configuration points are available:
 
 ## Reference
 
-For further information, please visit [the AzureDevOps provider docs](https://www.pulumi.com/docs/intro/cloud-providers/azuredevops) 
-or for detailed reference documentation, please visit [the API docs](https://www.pulumi.com/docs/reference/pkg/azuredevops).
+For further information, please visit [the AzureDevOps provider docs](https://www.pulumi.com/registry/packages/azuredevops/) 
+or for detailed reference documentation, please visit [the API docs](https://www.pulumi.com/registry/packages/azure-native/api-docs/).


### PR DESCRIPTION
Since the URLs of the documentation pages on the website were changed, need to reflect this in README as well