### PR TITLE
Update fork of terraform-provider-azuredevops

### DIFF
--- a/provider/go.mod
+++ b/provider/go.mod
@@ -5,7 +5,7 @@ go 1.16
 replace (
 	github.com/hashicorp/go-getter v1.5.0 => github.com/hashicorp/go-getter v1.4.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20201218231525-9cca98608a5e
-	github.com/microsoft/terraform-provider-azuredevops => github.com/pulumi/terraform-provider-azuredevops v0.1.3-0.20220420211229-578149558283
+	github.com/microsoft/terraform-provider-azuredevops => github.com/pulumi/terraform-provider-azuredevops v0.1.3-0.20220725180816-c415f7de3907
 	// Fixes a bug in codegen. Can be removed when the bridge references pulumi/pulumi >= 3.29.1:
 	github.com/pulumi/pulumi/pkg/v3 => github.com/pulumi/pulumi/pkg/v3 v3.29.1
 )

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -718,8 +718,8 @@ github.com/pulumi/terraform-diff-reader v0.0.0-20201211191010-ad4715e9285e h1:Di
 github.com/pulumi/terraform-diff-reader v0.0.0-20201211191010-ad4715e9285e/go.mod h1:sZ9FUzGO+yM41hsQHs/yIcj/Y993qMdBxBU5mpDmAfQ=
 github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20201218231525-9cca98608a5e h1:jl43csgF3BSlNRmjo+TGgjW/uXk9h7+NoR3doKQ0BT4=
 github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20201218231525-9cca98608a5e/go.mod h1:JBItawj+j8Ssla5Ib6BC/W9VQkOucBfnX7VRtyx1vw8=
-github.com/pulumi/terraform-provider-azuredevops v0.1.3-0.20220420211229-578149558283 h1:RkP5p5QiRv9cfFCIibY0uLeETjzYbeP27pzqbiXyQO0=
-github.com/pulumi/terraform-provider-azuredevops v0.1.3-0.20220420211229-578149558283/go.mod h1:nx9pgV8Jr5nCXgZotVdUbykhlJJ0NgKgCEFmAXLtjtQ=
+github.com/pulumi/terraform-provider-azuredevops v0.1.3-0.20220725180816-c415f7de3907 h1:C+DCT8Goh0+yD+PfknR4vToIba1PMpD73vhet0RfsTs=
+github.com/pulumi/terraform-provider-azuredevops v0.1.3-0.20220725180816-c415f7de3907/go.mod h1:nx9pgV8Jr5nCXgZotVdUbykhlJJ0NgKgCEFmAXLtjtQ=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rjeczalik/notify v0.9.2 h1:MiTWrPj55mNDHEiIX5YUSKefw/+lCQVoAFmD6oQm5w8=

--- a/sdk/dotnet/go.mod
+++ b/sdk/dotnet/go.mod
@@ -1,0 +1,3 @@
+module fake_dotnet_module // Exclude this directory from Go tools
+
+go 1.16

--- a/sdk/nodejs/go.mod
+++ b/sdk/nodejs/go.mod
@@ -1,0 +1,3 @@
+module fake_nodejs_module // Exclude this directory from Go tools
+
+go 1.16

--- a/sdk/python/go.mod
+++ b/sdk/python/go.mod
@@ -1,0 +1,3 @@
+module fake_python_module // Exclude this directory from Go tools
+
+go 1.16


### PR DESCRIPTION
This fixes an issue with variable groups where a ConflictsWith and a
DefaultValue on the same schema member prevent variable groups from
being usable with Azure Key Vault.

Fixes #52 