### PR TITLE
Upgrade terraform-provider-azuredevops to v1.1.1

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -138,7 +138,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/microsoft/azure-devops-go-api/azuredevops v1.0.0-b5 // indirect
 	github.com/microsoft/azure-devops-go-api/azuredevops/v7 v7.1.0 // indirect
-	github.com/microsoft/terraform-provider-azuredevops v1.1.0 // indirect
+	github.com/microsoft/terraform-provider-azuredevops v1.1.1 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-ps v1.0.0 // indirect

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -2486,8 +2486,8 @@ github.com/microsoft/azure-devops-go-api/azuredevops v1.0.0-b5 h1:YH424zrwLTlyHS
 github.com/microsoft/azure-devops-go-api/azuredevops v1.0.0-b5/go.mod h1:PoGiBqKSQK1vIfQ+yVaFcGjDySHvym6FM1cNYnwzbrY=
 github.com/microsoft/azure-devops-go-api/azuredevops/v7 v7.1.0 h1:mmJCWLe63QvybxhW1iBmQWEaCKdc4SKgALfTNZ+OphU=
 github.com/microsoft/azure-devops-go-api/azuredevops/v7 v7.1.0/go.mod h1:mDunUZ1IUJdJIRHvFb+LPBUtxe3AYB5MI6BMXNg8194=
-github.com/microsoft/terraform-provider-azuredevops v1.1.0 h1:gyX5iR7Zw4FW6B7qccCQEy9FuehUqCz09dzWrd0mpSc=
-github.com/microsoft/terraform-provider-azuredevops v1.1.0/go.mod h1:IaH2gx+YVIaJfJp3V/ndLZ9AWefG2gJDJkDCXpcwOVs=
+github.com/microsoft/terraform-provider-azuredevops v1.1.1 h1:k67b6KF/RscboGJZZlKUGyLO2No/IydU9Oi9zu0MGzQ=
+github.com/microsoft/terraform-provider-azuredevops v1.1.1/go.mod h1:IaH2gx+YVIaJfJp3V/ndLZ9AWefG2gJDJkDCXpcwOVs=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -8,7 +8,7 @@ replace (
 )
 
 require (
-	github.com/microsoft/terraform-provider-azuredevops v1.1.0
+	github.com/microsoft/terraform-provider-azuredevops v1.1.1
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.82.0
 	github.com/pulumi/pulumi/sdk/v3 v3.114.0
 )

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -2500,8 +2500,8 @@ github.com/microsoft/azure-devops-go-api/azuredevops v1.0.0-b5 h1:YH424zrwLTlyHS
 github.com/microsoft/azure-devops-go-api/azuredevops v1.0.0-b5/go.mod h1:PoGiBqKSQK1vIfQ+yVaFcGjDySHvym6FM1cNYnwzbrY=
 github.com/microsoft/azure-devops-go-api/azuredevops/v7 v7.1.0 h1:mmJCWLe63QvybxhW1iBmQWEaCKdc4SKgALfTNZ+OphU=
 github.com/microsoft/azure-devops-go-api/azuredevops/v7 v7.1.0/go.mod h1:mDunUZ1IUJdJIRHvFb+LPBUtxe3AYB5MI6BMXNg8194=
-github.com/microsoft/terraform-provider-azuredevops v1.1.0 h1:gyX5iR7Zw4FW6B7qccCQEy9FuehUqCz09dzWrd0mpSc=
-github.com/microsoft/terraform-provider-azuredevops v1.1.0/go.mod h1:IaH2gx+YVIaJfJp3V/ndLZ9AWefG2gJDJkDCXpcwOVs=
+github.com/microsoft/terraform-provider-azuredevops v1.1.1 h1:k67b6KF/RscboGJZZlKUGyLO2No/IydU9Oi9zu0MGzQ=
+github.com/microsoft/terraform-provider-azuredevops v1.1.1/go.mod h1:IaH2gx+YVIaJfJp3V/ndLZ9AWefG2gJDJkDCXpcwOVs=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=


### PR DESCRIPTION
This PR was generated via `$ upgrade-provider pulumi/pulumi-azuredevops --kind=all --target-bridge-version=latest`.

---

- Upgrading terraform-provider-azuredevops from 1.1.0  to 1.1.1.
	Fixes #391
