### PR TITLE
Create patch to remove problematic validation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "upstream"]
+	path = upstream
+	url = https://github.com/microsoft/terraform-provider-azuredevops.git
+	ignore = dirty

--- a/patches/0001-Revert-https-github.com-microsoft-terraform-provider.patch
+++ b/patches/0001-Revert-https-github.com-microsoft-terraform-provider.patch
@@ -1,0 +1,38 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Daniel Bradley <daniel@pulumi.com>
+Date: Tue, 3 Dec 2024 12:14:04 +0000
+Subject: [PATCH] Revert
+ https://github.com/microsoft/terraform-provider-azuredevops/pull/1075
+
+The validation always fails when running under the bridge because the bridge fills in the default values for values which are marked as ConflictsWith. Therefore, we'll remove this validation for the time being to unblock users from using the variable group resource.
+
+This can be removed once https://github.com/pulumi/pulumi-terraform-bridge/issues/2618 is resolved.
+
+Original customer issue: https://github.com/pulumi/pulumi-azuredevops/issues/514
+
+diff --git a/azuredevops/internal/service/taskagent/resource_variable_group.go b/azuredevops/internal/service/taskagent/resource_variable_group.go
+index f1d1cc18..7788bb97 100644
+--- a/azuredevops/internal/service/taskagent/resource_variable_group.go
++++ b/azuredevops/internal/service/taskagent/resource_variable_group.go
+@@ -381,21 +381,6 @@ func expandVariableGroupParameters(clients *client.AggregatedClient, d *schema.R
+ 	description := converter.String(d.Get(vgDescription).(string))
+ 	variables := d.Get(vgVariable).(*schema.Set).List()
+ 
+-	// needed to detect if the secret_value attribute is set in the config
+-	// see https://github.com/hashicorp/terraform-plugin-sdk/issues/741
+-	for it := d.GetRawConfig().AsValueMap()[vgVariable].ElementIterator(); it.Next(); {
+-		_, ctyVariable := it.Element()
+-		ctyVariableAsMap := ctyVariable.AsValueMap()
+-		name := ctyVariableAsMap[vgName].AsString()
+-		valueSet := !ctyVariableAsMap[vgValue].IsNull()
+-		secretValueSet := !ctyVariableAsMap[secretVgValue].IsNull()
+-		isSecretSet := !ctyVariableAsMap[vgIsSecret].IsNull()
+-
+-		if valueSet && (secretValueSet || isSecretSet) || secretValueSet != isSecretSet {
+-			return nil, nil, fmt.Errorf("`%s` variable can have either only `value` attribute or both `is_secret` and `secret_value` attributes", name)
+-		}
+-	}
+-
+ 	variableMap := make(map[string]interface{})
+ 
+ 	for _, variable := range variables {

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -12,6 +12,7 @@ replace (
 
 require (
 	github.com/microsoft/terraform-provider-azuredevops v1.4.0
+	github.com/pulumi/providertest v0.1.3
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.96.0
 	github.com/pulumi/pulumi/sdk/v3 v3.140.0
 )
@@ -59,6 +60,7 @@ require (
 	github.com/ettle/strcase v0.1.1 // indirect
 	github.com/fatih/color v1.16.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
+	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.5.0 // indirect
 	github.com/go-git/go-git/v5 v5.12.0 // indirect
@@ -133,6 +135,7 @@ require (
 	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/muesli/termenv v0.15.2 // indirect
 	github.com/natefinch/atomic v1.0.1 // indirect
+	github.com/nxadm/tail v1.4.11 // indirect
 	github.com/oklog/run v1.1.0 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/opentracing/basictracer-go v1.1.0 // indirect
@@ -203,6 +206,7 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240814211410-ddb44dafa142 // indirect
 	google.golang.org/grpc v1.67.1 // indirect
 	google.golang.org/protobuf v1.35.1 // indirect
+	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	lukechampine.com/frand v1.4.2 // indirect

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -7,6 +7,7 @@ toolchain go1.22.6
 replace (
 	github.com/hashicorp/go-getter v1.5.0 => github.com/hashicorp/go-getter v1.4.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20240520223432-0c0bf0d65f10
+	github.com/microsoft/terraform-provider-azuredevops => ../upstream
 )
 
 require (

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -1370,7 +1370,16 @@ github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3
 github.com/frankban/quicktest v1.14.3/go.mod h1:mgiwOwqx65TmIk1wJ6Q7wvnVMocbUorkibMOrVTHZps=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
+github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
+github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/gkampitakis/ciinfo v0.3.0 h1:gWZlOC2+RYYttL0hBqcoQhM7h1qNkVqvRCV1fOvpAv8=
+github.com/gkampitakis/ciinfo v0.3.0/go.mod h1:1NIwaOcFChN4fa/B0hEBdAb6npDlFL8Bwx4dfRLRqAo=
+github.com/gkampitakis/go-diff v1.3.2 h1:Qyn0J9XJSDTgnsgHRdz9Zp24RaJeKMUHg2+PDZZdC4M=
+github.com/gkampitakis/go-diff v1.3.2/go.mod h1:LLgOrpqleQe26cte8s36HTWcTmMEur6OPYerdAAS9tk=
+github.com/gkampitakis/go-snaps v0.4.9 h1:x6+GEQeYWC+cnLNsHK5uXXgEQADmlH/1EqMrjfXjzk8=
+github.com/gkampitakis/go-snaps v0.4.9/go.mod h1:8HW4KX3JKV8M0GSw69CvT+Jqhd1AlBPMPpBfjBI3bdY=
 github.com/gliderlabs/ssh v0.3.5/go.mod h1:8XB4KraRrX39qHhT6yxPsHedjA08I/uBVwj4xC+/+z4=
 github.com/gliderlabs/ssh v0.3.7 h1:iV3Bqi942d9huXnzEF2Mt+CY9gLu8DNM4Obd+8bODRE=
 github.com/gliderlabs/ssh v0.3.7/go.mod h1:zpHEXBstFnQYtGnB8k8kQLol82umzn/2/snG7alWVD8=
@@ -1816,6 +1825,8 @@ github.com/nightlyone/lockfile v1.0.0 h1:RHep2cFKK4PonZJDdEl4GmkabuhbsRMgk/k3uAm
 github.com/nightlyone/lockfile v1.0.0/go.mod h1:rywoIealpdNse2r832aiD9jRk8ErCatROs6LzC841CI=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
+github.com/nxadm/tail v1.4.11 h1:8feyoE3OzPrcshW5/MJ4sGESc5cqmGkGCWlco4l0bqY=
+github.com/nxadm/tail v1.4.11/go.mod h1:OTaG3NK980DZzxbRq6lEuzgU+mug70nY11sMd4JXXHc=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
@@ -2000,6 +2011,14 @@ github.com/teekennedy/goldmark-markdown v0.3.0 h1:ik9/biVGCwGWFg8dQ3KVm2pQ/wiiG0
 github.com/teekennedy/goldmark-markdown v0.3.0/go.mod h1:kMhDz8La77A9UHvJGsxejd0QUflN9sS+QXCqnhmxmNo=
 github.com/texttheater/golang-levenshtein v1.0.1 h1:+cRNoVrfiwufQPhoMzB6N0Yf/Mqajr6t1lOv8GyGE2U=
 github.com/texttheater/golang-levenshtein v1.0.1/go.mod h1:PYAKrbF5sAiq9wd+H82hs7gNaen0CplQ9uvm6+enD/8=
+github.com/tidwall/gjson v1.17.0 h1:/Jocvlh98kcTfpN2+JzGQWQcqrPQwDrVEMApx/M5ZwM=
+github.com/tidwall/gjson v1.17.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
+github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
+github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 github.com/uber/jaeger-client-go v2.30.0+incompatible h1:D6wyKGCecFaSRUpo8lCVbaOOb6ThwMmTEbhRwtKR97o=
 github.com/uber/jaeger-client-go v2.30.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v2.4.1+incompatible h1:td4jdvLcExb4cBISKIpHuGoVXh+dVKhn2Um6rjCsSsg=
@@ -2412,6 +2431,7 @@ golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220825204002-c680a09ffe64/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220829200755-d48e67d00261/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -2930,6 +2950,7 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EV
 gopkg.in/cheggaaa/pb.v1 v1.0.27/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -1763,8 +1763,6 @@ github.com/microsoft/azure-devops-go-api/azuredevops v1.0.0-b5 h1:YH424zrwLTlyHS
 github.com/microsoft/azure-devops-go-api/azuredevops v1.0.0-b5/go.mod h1:PoGiBqKSQK1vIfQ+yVaFcGjDySHvym6FM1cNYnwzbrY=
 github.com/microsoft/azure-devops-go-api/azuredevops/v7 v7.1.1-0.20241014080628-3045bdf43455 h1:7rDE4oHmFDgf+4fqnT5vztz7Bmcos1tr17VisCXgs/o=
 github.com/microsoft/azure-devops-go-api/azuredevops/v7 v7.1.1-0.20241014080628-3045bdf43455/go.mod h1:mDunUZ1IUJdJIRHvFb+LPBUtxe3AYB5MI6BMXNg8194=
-github.com/microsoft/terraform-provider-azuredevops v1.4.0 h1:1REMVy8hJsdZBK4iATDAU/JZmupDnDbd7fENTP3t1k8=
-github.com/microsoft/terraform-provider-azuredevops v1.4.0/go.mod h1:5lvWhm8cZfzwaUz3GUIxyqMQujHlliEsy7n4nrnyqZw=
 github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8/go.mod h1:mC1jAcsrzbxHt8iiaC+zU4b1ylILSosueou12R++wfY=
 github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3/go.mod h1:RagcQ7I8IeTMnF8JTXieKnO4Z6JCsikNEzj0DwauVzE=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -1,0 +1,41 @@
+package azuredevops
+
+import (
+	"context"
+	"path"
+	"testing"
+
+	_ "embed"
+
+	"github.com/pulumi/providertest/providers"
+	"github.com/pulumi/providertest/pulumitest"
+	"github.com/pulumi/providertest/pulumitest/opttest"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+
+	"github.com/pulumi/pulumi-azuredevops/provider/v3/pkg/version"
+)
+
+func TestVariableGroupValidation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+	pt := pulumitest.NewPulumiTest(t, path.Join("test-programs", "variable-group"),
+		opttest.AttachProviderServer("azuredevops", newTestProvider))
+
+	// This fails if running the upstream validation via the bridge
+	pt.Up(t)
+}
+
+// Use the non-embedded schema to avoid having to run generation before running the tests.
+//
+//go:embed cmd/pulumi-resource-azuredevops/schema.json
+var schemaBytes []byte
+
+func newTestProvider(_ providers.PulumiTest) (pulumirpc.ResourceProviderServer, error) {
+	version.Version = "0.0.1"
+	providerInfo := Provider()
+
+	return tfbridge.NewProvider(context.Background(), nil, "azuredevops",
+		version.Version, providerInfo.P, providerInfo, schemaBytes), nil
+}

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -57,18 +57,19 @@ func Provider() tfbridge.ProviderInfo {
 	}
 
 	prov := tfbridge.ProviderInfo{
-		P:            p,
-		Name:         "azuredevops",
-		DisplayName:  "Azure DevOps",
-		Description:  "A Pulumi package for creating and managing Azure DevOps.",
-		Keywords:     []string{"pulumi", "azuredevops"},
-		License:      "Apache-2.0",
-		Homepage:     "https://pulumi.io",
-		Repository:   "https://github.com/pulumi/pulumi-azuredevops",
-		GitHubOrg:    "microsoft",
-		Version:      version.Version,
-		MetadataInfo: tfbridge.NewProviderMetadata(metadata),
-		DocRules:     &tfbridge.DocRuleInfo{EditRules: docEditRules},
+		P:                p,
+		Name:             "azuredevops",
+		DisplayName:      "Azure DevOps",
+		Description:      "A Pulumi package for creating and managing Azure DevOps.",
+		Keywords:         []string{"pulumi", "azuredevops"},
+		License:          "Apache-2.0",
+		Homepage:         "https://pulumi.io",
+		Repository:       "https://github.com/pulumi/pulumi-azuredevops",
+		GitHubOrg:        "microsoft",
+		UpstreamRepoPath: "./upstream",
+		Version:          version.Version,
+		MetadataInfo:     tfbridge.NewProviderMetadata(metadata),
+		DocRules:         &tfbridge.DocRuleInfo{EditRules: docEditRules},
 		Config: map[string]*tfbridge.SchemaInfo{
 			"org_service_url": {
 				Default: &tfbridge.DefaultInfo{

--- a/provider/test-programs/variable-group/Pulumi.yaml
+++ b/provider/test-programs/variable-group/Pulumi.yaml
@@ -1,0 +1,16 @@
+name: variable-group
+runtime: yaml
+
+resources:
+  exampleProject:
+    type: azuredevops:index/project:Project
+  exampleInsights:
+    type: azuredevops:index/variableGroup:VariableGroup
+    properties:
+      projectId: ${exampleProject.id}
+      name: variablegroupname
+      description: my description
+      allowAccess: false
+      variables:
+        - name: key1
+          value: val1

--- a/upstream.sh
+++ b/upstream.sh
@@ -138,11 +138,14 @@ apply_patches() {
   # Iterating over the patches folder in sorted order,
   # apply the patch using a 3-way merge strategy. This mirrors the default behavior of 'git merge'
   cd upstream
+  # Allow directory to be empty
+  shopt -s nullglob
   for patch in ../patches/*.patch; do
     if ! git apply --3way "${patch}" --allow-empty; then
       err_failed_to_apply "$(basename "${patch}")"
     fi
   done
+  shopt -u nullglob
 }
 
 clean_rebases() {
@@ -227,13 +230,16 @@ checkout() {
   # Create a new branch 'pulumi/patch-checkout' which will contain the commits for each patch
   git checkout -B pulumi/patch-checkout
 
+  # Allow directory to be empty
+  shopt -s nullglob
   for patch in ../patches/*.patch; do
     if ! git am --3way "${patch}"; then
       err_failed_to_apply "$(basename "${patch}")"
     fi
   done
+  shopt -u nullglob
 
-    cat <<EOF
+  cat <<EOF
 
 The patches have been checked out as commits in the './upstream' repository.
 The 'pulumi/patch-checkout' branch is pointing to the last patch.


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-azuredevops/issues/514

The validation always fails when running under the bridge because the bridge fills in the default values for values which are marked as ConflictsWith. Therefore, we'll remove this validation for the time being to unblock users from using the variable group resource.

This can be removed once https://github.com/pulumi/pulumi-terraform-bridge/issues/2618 is resolved.