### PR TITLE
Remove `make upstream` from `preTest`

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -5,10 +5,6 @@ env:
   AZDO_PERSONAL_ACCESS_TOKEN: ${{ secrets.AZDO_PERSONAL_ACCESS_TOKEN }}
 makeTemplate: bridged
 checkoutSubmodules: true
-actions:
-  preTest:
-    - name: Make upstream
-      run: make upstream
 plugins:
   - name: terraform
     version: "1.0.16"

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -134,6 +134,9 @@ jobs:
       - prerequisites
       - build_provider
       - build_sdk
+    permissions:
+      contents: read
+      id-token: write
     secrets: inherit
     with:
       version: ${{ needs.prerequisites.outputs.version }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -74,6 +74,9 @@ jobs:
       - prerequisites
       - build_provider
       - build_sdk
+    permissions:
+      contents: read
+      id-token: write
     secrets: inherit
     with:
       version: ${{ needs.prerequisites.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,9 @@ jobs:
       - prerequisites
       - build_provider
       - build_sdk
+    permissions:
+      contents: read
+      id-token: write
     secrets: inherit
     with:
       version: ${{ needs.prerequisites.outputs.version }}

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -123,6 +123,9 @@ jobs:
       - prerequisites
       - build_provider
       - build_sdk
+    permissions:
+      contents: read
+      id-token: write
     secrets: inherit
     with:
       version: ${{ needs.prerequisites.outputs.version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,8 +80,6 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         version: v2.5.0
-    - name: Make upstream
-      run: make upstream
     - name: Run tests
       if: matrix.testTarget == 'local'
       run: cd examples && go test -v -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -skip TestPulumiExamples -parallel 4 .


### PR DESCRIPTION
After https://github.com/pulumi/ci-mgmt/pull/1151 our `make` targets should now all correctly call `make upstream` if they need it.

This updates `.ci-mgmt.yaml` and re-runs `make ci-mgmt`.