### PR TITLE
Don't auto-merge upstream upgrades

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -14,3 +14,4 @@ plugins:
     version: "5.66.1"
 pulumiConvert: 1
 registryDocs: true
+autoMergeProviderUpgrades: false


### PR DESCRIPTION
Sets the `AutoMergeProviderUpgrades` ci-mgmt config to false to avoid auto-merging upstream upgrades. This maintains the current behaviour.

Part of https://github.com/pulumi/ci-mgmt/issues/1344